### PR TITLE
переименование устройства

### DIFF
--- a/modules/ssdpdevices/ssdpdevices_structure.inc.php
+++ b/modules/ssdpdevices/ssdpdevices_structure.inc.php
@@ -71,7 +71,7 @@ $this->ssdpdevices_types=array(
         ),
     ),
     'MediaRenderer'=>array(
-        'TITLE'=>'UPNP Телевизор',
+        'TITLE'=>'UPNP Медиа рендер',
         'PARENT_CLASS'=>'UPNPdevices',
         'CLASS'=>'SMediaRenderer',
         'PROPERTIES'=>array(


### PR DESCRIPTION
т.к. в качестве медиа рендера может выступать не только телевизор, предлагаю дать более уточнённое название этому типу устройств.