### PR TITLE
Автоотключение кнопки

### DIFF
--- a/templates/ssdp_finder/ssdp_devices_edit.html
+++ b/templates/ssdp_finder/ssdp_devices_edit.html
@@ -134,13 +134,13 @@
                 <input type="checkbox" name="create_od" checked>
             </div>
             <div class="controls">
-                <input type="checkbox" name="create_term" checked>
+                <input type="checkbox" name="create_term" [#if TYPE="MediaRenderer"#] checked [#else#] disabled [#endif#]>
             </div>
             <div class="controls">
                 <input type="checkbox" name="create_templ" checked>
             </div>
             <div class="controls">
-                <input type="checkbox" name="use_to_say" checked>
+                <input type="checkbox" name="use_to_say" [#if TYPE="MediaRenderer"#] checked [#else#] disabled [#endif#]>
             </div>
         </div>
         [#module name="linkedobject" object_field="linked_object" property_field="linked_property" method_field="linked_method"#]


### PR DESCRIPTION
Если устройство не МедиаРендерер то необходимо отключить кнопку создания терминала и кнопку использования устройства для проговаривания ответов Алисы из чатбокса